### PR TITLE
Add missing utility file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN yum makecache
 RUN yum install -y gawk make wget tar bzip2 gzip python unzip perl patch \
 diffutils diffstat git cpp gcc gcc-c++ glibc-devel texinfo chrpath socat \
 perl-Data-Dumper perl-Text-ParseWords perl-Thread-Queue python34-pip xz \
-which SDL-devel xterm 
+which SDL-devel xterm file


### PR DESCRIPTION
Fixing:
ERROR:  OE-core's config sanity checker detected a potential misconfiguration.
    Either fix the cause of this error or at your own risk disable the checker (see sanity.conf).
    Following is the list of potential problems / advisories:
    Please install the following missing utilities: file